### PR TITLE
feat: update terraform to 1.2 min and aws provider to 4.0 min

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1]
+* Update terraform minimum to 1.2 and aws provider minimum to 4.0
+
 ## [0.1.0]
 * Initial version

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ data "aws_iam_policy_document" "this" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 services:
 
   terraform:
-    image: hashicorp/terraform:1.1.7
+    image: hashicorp/terraform:1.2.3
     volumes:
       - '.:/app'
       - '~/.aws:/root/.aws:ro'

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0.5"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.64"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
## Related Tasks

- None

## Depends on

- None

## What

- Update terraform minimum to 1.2 and aws provider minimum to 4.0

## Why

- Keep versions up to date

## Concerns

- Potential compatibility issues but will be versioned so consumers can choose to use older version.



* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
