### PR TITLE
HAI-510 Functionality for user supplied lifecycle policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2]
+* Adds the ability to override the default lifecycle policy with a custom user supplied policy
+
+Please note that when switching from the default to user supplied lifecycle policy, it may be neccessary to `terraform apply` twice.  This is due to a nuance in the terraform resource lifecycle and not easily worked around
+
 ## [0.1.1]
 * Update terraform minimum to 1.2 and aws provider minimum to 4.0
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @harrison-ai/data
+* @harrison-ai/platform

--- a/README.md
+++ b/README.md
@@ -35,32 +35,10 @@ module "example" {
 }
 ```
 
-### Override Default Policy with User Supplied Policy
+### Override lifecycle or repository policy
 
-```terraform
-module "example" {
-  source = "git@github.com:harrison-ai/harrison-terraform-module-ecr.git"
+Both the lifecycle policy and repository policy can be overriden with custom user supplied policies.  Please see `examples/user-supplied-policies` for a complete example
 
-  name            = "example"
-  override_policy = true
-  policy          = data.aws_iam_policy_document.this.json
-}
-
-data "aws_iam_policy_document" "this" {
-  statement {
-    sid    = "01"
-    effect = "Allow"
-    actions = [
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage"
-    ]
-    principals {
-      type        = "AWS"
-      identifiers = ["012345678912"]
-    }
-  }
-}
-```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -84,19 +62,23 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_ecr_lifecycle_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) | resource |
 | [aws_ecr_lifecycle_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) | resource |
 | [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_ecr_repository_policy.override](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | List of AWS Account ID's that will be granted access to the repository | `list(string)` | `[]` | no |
+| <a name="input_lifecycle_policy"></a> [lifecycle\_policy](#input\_lifecycle\_policy) | A lifecycle policy to override the default policy | `map(any)` | `null` | no |
 | <a name="input_mutable_tags"></a> [mutable\_tags](#input\_mutable\_tags) | Boolean setting for repository tag mutability | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the ECR Repository | `string` | n/a | yes |
+| <a name="input_override_lifecycle_policy"></a> [override\_lifecycle\_policy](#input\_override\_lifecycle\_policy) | Boolean setting to override the default lifecycle policy | `bool` | `false` | no |
 | <a name="input_override_policy"></a> [override\_policy](#input\_override\_policy) | Boolean setting to override the default policy | `bool` | `false` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | A json encoded policy to override the default policy | `string` | `null` | no |
 | <a name="input_tagged_images_to_keep"></a> [tagged\_images\_to\_keep](#input\_tagged\_images\_to\_keep) | Number of tagged images to keep | `number` | `5` | no |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 services:
 
   terraform:
-    image: hashicorp/terraform:1.2.3
+    image: hashicorp/terraform:1.2.8
     volumes:
       - '.:/app'
       - '~/.aws:/root/.aws:ro'

--- a/examples/complete/locals.tf
+++ b/examples/complete/locals.tf
@@ -1,0 +1,1 @@
+../locals.tf

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,0 +1,15 @@
+# complete example with cross account sharing
+
+resource "random_pet" "this" {
+  length    = 2
+  separator = "-"
+}
+
+module "example" {
+  source = "../../"
+
+  name                    = random_pet.this.id
+  account_ids             = ["012345678912"]
+  tagged_images_to_keep   = 30
+  untagged_images_to_keep = 3
+}

--- a/examples/complete/provider.tf
+++ b/examples/complete/provider.tf
@@ -1,0 +1,1 @@
+../provider.tf

--- a/examples/locals.tf
+++ b/examples/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  region = "ap-southeast-2"
+}

--- a/examples/minimal/locals.tf
+++ b/examples/minimal/locals.tf
@@ -1,0 +1,1 @@
+../locals.tf

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -1,0 +1,12 @@
+# minimal example with no cross account sharing
+
+resource "random_pet" "this" {
+  length    = 2
+  separator = "-"
+}
+
+module "example" {
+  source = "../../"
+
+  name = random_pet.this.id
+}

--- a/examples/minimal/provider.tf
+++ b/examples/minimal/provider.tf
@@ -1,0 +1,1 @@
+../provider.tf

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.3.2"
+    }
+  }
+}
+
+provider "aws" {
+  region = local.region
+}

--- a/examples/user-supplied-policies/locals.tf
+++ b/examples/user-supplied-policies/locals.tf
@@ -1,0 +1,1 @@
+../locals.tf

--- a/examples/user-supplied-policies/main.tf
+++ b/examples/user-supplied-policies/main.tf
@@ -1,0 +1,102 @@
+# override default lifecycle policy and repository policy with user supplied policies
+
+locals {
+
+  untagged_policy = {
+    rulePriority = 1
+    description  = "Expire untagged Images"
+    selection = {
+      tagStatus   = "untagged"
+      countType   = "imageCountMoreThan"
+      countNumber = 1
+    }
+    action = {
+      type = "expire"
+    }
+  }
+
+  prod_policy = {
+    rulePriority = 2
+    description  = "Expire production Images"
+    selection = {
+      tagStatus     = "tagged"
+      tagPrefixList = ["prod"]
+      countType     = "imageCountMoreThan"
+      countNumber   = 10
+    }
+    action = {
+      type = "expire"
+    }
+  }
+
+  dev_policy = {
+    rulePriority = 3
+    description  = "Expire dev Images"
+    selection = {
+      tagStatus     = "tagged"
+      tagPrefixList = ["dev"]
+      countType     = "imageCountMoreThan"
+      countNumber   = 10
+    }
+    action = {
+      type = "expire"
+    }
+  }
+
+  tagged_policy = {
+    rulePriority = 4
+    description  = "Expire images that don't match above rules"
+    selection = {
+      tagStatus   = "any"
+      countType   = "imageCountMoreThan"
+      countNumber = 10
+    }
+    action = {
+      type = "expire"
+    }
+  }
+
+  #  user supplied lifecycle policy
+  effective_policy = {
+    rules = [
+      local.untagged_policy,
+      local.prod_policy,
+      local.dev_policy,
+      local.tagged_policy,
+    ]
+  }
+
+}
+
+#  user supplied repository policy
+data "aws_iam_policy_document" "this" {
+  statement {
+    sid    = "01"
+    effect = "Allow"
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["552365532775"]
+    }
+  }
+}
+
+
+resource "random_pet" "this" {
+  length    = 2
+  separator = "-"
+}
+
+
+module "example" {
+  source = "../../"
+
+  name                      = random_pet.this.id
+  override_policy           = true
+  policy                    = data.aws_iam_policy_document.this.json
+  override_lifecycle_policy = true
+  lifecycle_policy          = local.effective_policy
+}

--- a/examples/user-supplied-policies/provider.tf
+++ b/examples/user-supplied-policies/provider.tf
@@ -1,0 +1,1 @@
+../provider.tf

--- a/main.tf
+++ b/main.tf
@@ -81,3 +81,9 @@ data "aws_iam_policy_document" "default" {
     }
   }
 }
+
+
+moved {
+  from = module.example.aws_ecr_lifecycle_policy.this
+  to   = module.example.aws_ecr_lifecycle_policy.this[0]
+}

--- a/main.tf
+++ b/main.tf
@@ -10,9 +10,21 @@ resource "aws_ecr_repository" "this" {
 }
 
 
-resource "aws_ecr_lifecycle_policy" "this" {
+# default lifecycle policy if override lifecycle policy is not supplied
+resource "aws_ecr_lifecycle_policy" "default" {
+  count = var.override_lifecycle_policy ? 0 : 1
+
   repository = aws_ecr_repository.this.name
   policy     = jsonencode(local.effective_policy)
+}
+
+
+# override lifecycle policy - user supplied
+resource "aws_ecr_lifecycle_policy" "this" {
+  count = var.override_lifecycle_policy ? 1 : 0
+
+  repository = aws_ecr_repository.this.name
+  policy     = jsonencode(var.lifecycle_policy)
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,15 @@ variable "policy" {
   default     = null
   description = "A json encoded policy to override the default policy"
 }
+
+variable "override_lifecycle_policy" {
+  type        = bool
+  default     = false
+  description = "Boolean setting to override the default lifecycle policy"
+}
+
+variable "lifecycle_policy" {
+  type        = map(any)
+  default     = null
+  description = "A lifecycle policy to override the default policy"
+}


### PR DESCRIPTION
## Related Tasks

N/A

## Depends on

N/A

## What

- Add functionality to override default lifecycle policy with custom user supplied policy
- Created proper examples
- Update CODEOWNERS
- Update Terraform version in Docker Compose stack

## Why

Missing functionality as requested by a downstream JV

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
