### PR TITLE
feat: Enable cross account EKS pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 A Terraform Module to be used for deploying ECR Repositories with the following design goals:
 
-- Selected AWS Accounts can pull from repository
-- The ability to provide a custom ECR Resource Policy
+- Allow Lambda or EKS from selected AWS Accounts to pull from repository.
+- The ability to provide a custom ECR Resource Policy.
 - Aggressive by default lifecycle policy:
-    - 1 x Untagged image allowed
-    - 10 x Tagged images allowed
+    - 1 x Untagged image allowed.
+    - 10 x Tagged images allowed.
 
-Opinionated in that this is designed primarily for publishing Docker images into a central or shared AWS account, from which they are to be consumed via `docker pull` in other AWS Accounts.
+Opinionated in that this is designed primarily for publishing Docker images into a central or shared AWS account, from which they are to be consumed via EKS or Lambda functions in other AWS Accounts.
 
 ## Usage
 
@@ -28,8 +28,9 @@ module "example" {
 module "example" {
   source = "github.com/harrison-ai/harrison-terraform-module-ecr?ref=0.1.3"
 
-  name                    = "example"
-  account_ids             = ["012345678912"]
+  name                    = random_pet.this.id
+  account_ids             = ["012345678912", "001122334455"]
+  cross_account_service   = "EKS"
   tagged_images_to_keep   = 30
   untagged_images_to_keep = 3
 }
@@ -68,6 +69,8 @@ No modules.
 | [aws_ecr_repository_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_ecr_repository_policy.override](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eks_cross_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda_cross_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -75,6 +78,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | List of AWS Account ID's that will be granted access to the repository | `list(string)` | `[]` | no |
+| <a name="input_cross_account_service"></a> [cross\_account\_service](#input\_cross\_account\_service) | The service for which to configure cross account pull permissions on the repo.  Valid options are EKS or Lambda | `string` | `null` | no |
 | <a name="input_lifecycle_policy"></a> [lifecycle\_policy](#input\_lifecycle\_policy) | A lifecycle policy to override the default policy | `map(any)` | `null` | no |
 | <a name="input_mutable_tags"></a> [mutable\_tags](#input\_mutable\_tags) | Boolean setting for repository tag mutability | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the ECR Repository | `string` | n/a | yes |
@@ -89,6 +93,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_repository_arn"></a> [repository\_arn](#output\_repository\_arn) | ECR Repository ARN |
 | <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | ECR Repository URL |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -9,7 +9,8 @@ module "example" {
   source = "../../"
 
   name                    = random_pet.this.id
-  account_ids             = ["012345678912"]
+  account_ids             = ["012345678912", "001122334455"]
+  cross_account_service   = "EKS"
   tagged_images_to_keep   = 30
   untagged_images_to_keep = 3
 }

--- a/locals.tf
+++ b/locals.tf
@@ -33,4 +33,7 @@ locals {
     ]
   }
 
+  lambda_cross_account_enabled = alltrue([length(var.account_ids) > 0, var.cross_account_service == "Lambda"])
+  eks_cross_account_enabled    = alltrue([length(var.account_ids) > 0, var.cross_account_service == "EKS"])
+
 }

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,6 @@ resource "aws_ecr_repository" "this" {
   }
 }
 
-
 # default lifecycle policy if override lifecycle policy is not supplied
 resource "aws_ecr_lifecycle_policy" "default" {
   count = var.override_lifecycle_policy ? 0 : 1
@@ -30,7 +29,7 @@ resource "aws_ecr_lifecycle_policy" "this" {
 }
 
 
-# created if account_ids are not supplied and override_policy is true
+# override repo policy - user supplied
 resource "aws_ecr_repository_policy" "override" {
   count      = length(var.account_ids) == 0 && var.override_policy ? 1 : 0
   repository = aws_ecr_repository.this.name
@@ -38,23 +37,31 @@ resource "aws_ecr_repository_policy" "override" {
 
 }
 
-
-# created if account_ids are supplied and override_policy is false
+# default repo policy if cross account pull access is desired and override repo policy is not provided
 resource "aws_ecr_repository_policy" "default" {
-  count = length(var.account_ids) > 0 && !var.override_policy ? 1 : 0
+  count = (local.eks_cross_account_enabled || local.lambda_cross_account_enabled) && !var.override_policy ? 1 : 0
 
   repository = aws_ecr_repository.this.name
   policy     = data.aws_iam_policy_document.default[0].json
 }
 
-
-# default policy if cross account ids are supplied
-# if no cross account ids are supplied, no policy is created
+# default repo policy if cross account pull access is desired
+# configures a policy for cross account pulls from either EKS or Lambda
 data "aws_iam_policy_document" "default" {
-  count = length(var.account_ids) > 0 ? 1 : 0
+  count = anytrue([local.eks_cross_account_enabled, local.lambda_cross_account_enabled]) ? 1 : 0
+
+  source_policy_documents = [
+    local.eks_cross_account_enabled ? data.aws_iam_policy_document.eks_cross_account[0].json : jsonencode({}),
+    local.lambda_cross_account_enabled ? data.aws_iam_policy_document.lambda_cross_account[0].json : jsonencode({}),
+  ]
+}
+
+# Lambda cross account pull policy
+data "aws_iam_policy_document" "lambda_cross_account" {
+  count = local.lambda_cross_account_enabled ? 1 : 0
 
   statement {
-    sid    = "AllowAccountID"
+    sid    = "AllowLambdaAccountID"
     effect = "Allow"
     actions = [
       "ecr:GetDownloadUrlForLayer",
@@ -66,7 +73,7 @@ data "aws_iam_policy_document" "default" {
     }
   }
   statement {
-    sid    = "AllowService"
+    sid    = "AllowLambdaCrossAccountPull"
     effect = "Allow"
     actions = [
       "ecr:GetDownloadUrlForLayer",
@@ -79,11 +86,33 @@ data "aws_iam_policy_document" "default" {
     condition {
       test     = "StringLike"
       variable = "aws:sourceARN"
-      values   = [for id in var.account_ids : "arn:aws:lambda:${data.aws_region.current.name}:${id}:function:*"]
+      values   = [for id in var.account_ids : "arn:aws:lambda:${data.aws_region.current.region}:${id}:function:*"]
     }
   }
 }
 
+# EKS cross account pull policy
+data "aws_iam_policy_document" "eks_cross_account" {
+  count = local.eks_cross_account_enabled ? 1 : 0
+
+  statement {
+    sid    = "AllowEKSCrossAccountPull"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:DescribeRepositories",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:ListImages",
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        for account in var.account_ids : "arn:aws:iam::${account}:root"
+      ]
+    }
+  }
+}
 
 moved {
   from = module.example.aws_ecr_lifecycle_policy.this

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,23 @@
-variable "name" {
+variable "account_ids" {
+  type        = list(string)
+  default     = []
+  description = "List of AWS Account ID's that will be granted access to the repository"
+}
+
+variable "cross_account_service" {
   type        = string
-  description = "Name of the ECR Repository"
+  default     = null
+  description = "The service for which to configure cross account pull permissions on the repo.  Valid options are EKS or Lambda"
+  validation {
+    condition     = var.cross_account_service != null ? contains(["EKS", "Lambda"], var.cross_account_service) : true
+    error_message = "Value must be one of: EKS or Lambda"
+  }
+}
+
+variable "lifecycle_policy" {
+  type        = map(any)
+  default     = null
+  description = "A lifecycle policy to override the default policy"
 }
 
 variable "mutable_tags" {
@@ -9,22 +26,15 @@ variable "mutable_tags" {
   description = "Boolean setting for repository tag mutability"
 }
 
-variable "account_ids" {
-  type        = list(string)
-  default     = []
-  description = "List of AWS Account ID's that will be granted access to the repository"
+variable "name" {
+  type        = string
+  description = "Name of the ECR Repository"
 }
 
-variable "untagged_images_to_keep" {
-  type        = number
-  default     = 1
-  description = "Number of untagged images to keep"
-}
-
-variable "tagged_images_to_keep" {
-  type        = number
-  default     = 5
-  description = "Number of tagged images to keep"
+variable "override_lifecycle_policy" {
+  type        = bool
+  default     = false
+  description = "Boolean setting to override the default lifecycle policy"
 }
 
 variable "override_policy" {
@@ -39,20 +49,20 @@ variable "policy" {
   description = "A json encoded policy to override the default policy"
 }
 
-variable "override_lifecycle_policy" {
-  type        = bool
-  default     = false
-  description = "Boolean setting to override the default lifecycle policy"
-}
-
-variable "lifecycle_policy" {
-  type        = map(any)
-  default     = null
-  description = "A lifecycle policy to override the default policy"
+variable "tagged_images_to_keep" {
+  type        = number
+  default     = 5
+  description = "Number of tagged images to keep"
 }
 
 variable "tags" {
   type        = map(string)
   default     = {}
   description = "A map of tags to assign to the resource"
+}
+
+variable "untagged_images_to_keep" {
+  type        = number
+  default     = 1
+  description = "Number of untagged images to keep"
 }


### PR DESCRIPTION
## What

This PR adds an optional repo policy that allows cross account pulls from EKS, in the same manner as the existing functionality for Lambda.
