### PR TITLE
feat: Enhanced Region Support in AWS Provider v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ No modules.
 | <a name="input_override_lifecycle_policy"></a> [override\_lifecycle\_policy](#input\_override\_lifecycle\_policy) | Boolean setting to override the default lifecycle policy | `bool` | `false` | no |
 | <a name="input_override_policy"></a> [override\_policy](#input\_override\_policy) | Boolean setting to override the default policy | `bool` | `false` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | A json encoded policy to override the default policy | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS Region in which to create resources | `string` | `null` | no |
 | <a name="input_tagged_images_to_keep"></a> [tagged\_images\_to\_keep](#input\_tagged\_images\_to\_keep) | Number of tagged images to keep | `number` | `5` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resource | `map(string)` | `{}` | no |
 | <a name="input_untagged_images_to_keep"></a> [untagged\_images\_to\_keep](#input\_untagged\_images\_to\_keep) | Number of untagged images to keep | `number` | `1` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,12 @@
-data "aws_region" "current" {}
+data "aws_region" "current" {
+  region = var.region
+}
 
 
 resource "aws_ecr_repository" "this" {
   name                 = var.name
   image_tag_mutability = var.mutable_tags ? "MUTABLE" : "IMMUTABLE"
+  region               = var.region
   tags                 = var.tags
 
   image_scanning_configuration {
@@ -15,6 +18,7 @@ resource "aws_ecr_repository" "this" {
 resource "aws_ecr_lifecycle_policy" "default" {
   count = var.override_lifecycle_policy ? 0 : 1
 
+  region     = var.region
   repository = aws_ecr_repository.this.name
   policy     = jsonencode(local.effective_policy)
 }
@@ -24,6 +28,7 @@ resource "aws_ecr_lifecycle_policy" "default" {
 resource "aws_ecr_lifecycle_policy" "this" {
   count = var.override_lifecycle_policy ? 1 : 0
 
+  region     = var.region
   repository = aws_ecr_repository.this.name
   policy     = jsonencode(var.lifecycle_policy)
 }
@@ -31,7 +36,9 @@ resource "aws_ecr_lifecycle_policy" "this" {
 
 # override repo policy - user supplied
 resource "aws_ecr_repository_policy" "override" {
-  count      = length(var.account_ids) == 0 && var.override_policy ? 1 : 0
+  count = length(var.account_ids) == 0 && var.override_policy ? 1 : 0
+
+  region     = var.region
   repository = aws_ecr_repository.this.name
   policy     = var.policy
 
@@ -41,6 +48,7 @@ resource "aws_ecr_repository_policy" "override" {
 resource "aws_ecr_repository_policy" "default" {
   count = (local.eks_cross_account_enabled || local.lambda_cross_account_enabled) && !var.override_policy ? 1 : 0
 
+  region     = var.region
   repository = aws_ecr_repository.this.name
   policy     = data.aws_iam_policy_document.default[0].json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,11 @@ variable "override_policy" {
   description = "Boolean setting to override the default policy"
 }
 
+variable "region" {
+  type        = string
+  description = "The AWS Region in which to create resources"
+  default     = null
+}
 variable "policy" {
   type        = string
   default     = null


### PR DESCRIPTION
## What

Enable usage of the Enhanced Region Support in the Terraform AWS v6 Provider

## Why

Simplify calling modules, eliminating the requirement for aliased providers.
